### PR TITLE
🐛 Fix names in CMakeLists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(dbuf "main.cpp")
+add_executable(dbuf "main.cc")
 target_compile_options(dbuf PRIVATE -Wall -Wextra -Wpedantic -fsanitize=undefined)
 target_link_libraries(dbuf PRIVATE core)
 target_link_options(dbuf PRIVATE -fsanitize=undefined)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
-add_executable(dbufTests parser_test.cpp)
+add_executable(dbufTests "parser_test.cc")
 target_link_libraries(dbufTests PRIVATE core gtest gtest_main pthread)
 
 include(GoogleTest)


### PR DESCRIPTION
Some files weren't renamed from .cpp to .cc in the CMakeLists