### PR TITLE
🩹 Add a case for clang-tidy bug, temporary fix

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -89,6 +89,7 @@ CheckOptions:
   - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
   - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
   - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
+  - { key: readability-identifier-naming.TypeTemplateParameterIgnoredRegexp, value: expr-type }
   - { key: readability-identifier-naming.FunctionCase,           value: aNy_CasE  }
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
   - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }


### PR DESCRIPTION
Currently, clang-tidy reports an error `invalid case error for template parameter 'expr-type'`, check out this related issue: https://github.com/llvm/llvm-project/issues/46097
We need to come up with a better fix.