### PR TITLE
Fix suitable constructor check in type comparator

### DIFF
--- a/lib/core/checker/type_comparator.cc
+++ b/lib/core/checker/type_comparator.cc
@@ -51,7 +51,7 @@ struct Matcher {
   }
 
   bool operator()(const ast::Value &arg, const ast::Value &pattern) {
-    DLOG(INFO) << "Matching Value " << arg << " against Value" << pattern;
+    DLOG(INFO) << "Matching Value " << arg << " against Value " << pattern;
     return std::visit(*this, arg, pattern);
   }
 
@@ -297,6 +297,8 @@ std::optional<Error> TypeComparator::operator()(const ast::ConstructedValue &val
       DLOG(INFO) << "Found constructor " << constructor.identifier.name << ", checking fields";
       return CheckConstructedValue(val, constructor);
     }
+    // Break because we already found a matching pattern but didn't find any suitable constructors
+    break;
   }
   return Error(
       CreateError() << "Constructor \"" << val.constructor_identifier.name << "\" cannot be used in this context at "


### PR DESCRIPTION
When looking for suitable constructors we do not stop at the first matched rule and continue looking in other rules, which doesn't comply with the spec.

Right now if we have a file like this
```dbuf
enum Foo (x Int) {
  5 => {
    Foo5 {
      m Int;
    }
  }
  * => {
    FooElse {
      s String;
    }
  }
}

message A (f Foo 5) {
  x Int;
}

message B {
  a A Foo5{m: 2};
  a2 A FooElse{s: "huh"};
}
```

it doesn't get flagged as incorrect, even though `FooElse` is not in the `5` branch of the `Foo` rule list. This fix ensures that when we find a matching rule we stop the search there and then.